### PR TITLE
Fix for #27

### DIFF
--- a/src/app/rebate/pd-rebate-card/pd-rebate-card.component.css
+++ b/src/app/rebate/pd-rebate-card/pd-rebate-card.component.css
@@ -12,6 +12,10 @@
     font-weight: 700;
 }
 
+/* #stud-room-number {
+    color: #888;
+} */
+
 #stud-sub-details-container{
     margin: 12px 0px;
     font-size: 1.25rem;

--- a/src/app/rebate/pd-rebate-card/pd-rebate-card.component.html
+++ b/src/app/rebate/pd-rebate-card/pd-rebate-card.component.html
@@ -6,7 +6,7 @@
         <!-- <span>{{ rebate_request.student.name }}</span> -->
     </div>
     <div id="stud-sub-details-container">
-        <span>{{ rebate_request.fullname}} Room:{{rebate_request.room}}</span>
+        <span>{{ rebate_request.fullname}} • Room:{{rebate_request.room}}</span>
         <br>
         <!-- <span>{{ rebate_request.student.name }}</span> -->
     </div>

--- a/src/app/student-list/student-list.component.ts
+++ b/src/app/student-list/student-list.component.ts
@@ -57,10 +57,15 @@ export class StudentListComponent implements OnInit {
         
           this.temp = res;
           // console.log(this.temp)
-          this.studentInfoList = Object.entries(this.temp);
-      }).catch((res)=>{
-        this.errMsg = res
-      })
+          // this.studentInfoList = Object.entries(this.temp);
+          this.studentInfoList = Object.entries(this.temp).map(item => {
+            let student = item[1] as any;
+            student.room = student.room?.replace(/^\-\s*/, '');
+            return [item[0], student];
+          });
+          }).catch((res)=>{
+            this.errMsg = res
+          });
     }
 
   async toggl(currStudRoll:any){

--- a/src/app/studentcard/studentcard.component.html
+++ b/src/app/studentcard/studentcard.component.html
@@ -15,7 +15,7 @@
                     </div>                                      
                     <div class="space"> 
                         <p id="studrollno">{{student.id}}</p>
-                        <p>Hostel {{student.hostel}} {{student.room}} </p>
+                        <p>Hostel {{student.hostel}} - {{student.room}} </p>
                     </div>
                 </div>
                     <br> 


### PR DESCRIPTION
Fixes #27 
- Leading `-` in room numbers on the Students' List page is removed on obtaining data from service. Leads to leading `-` not being present on Student Details page also.
- Bullet point added between name and room number